### PR TITLE
Adds booleans and enhancements to snippets

### DIFF
--- a/grammars/openscad.cson
+++ b/grammars/openscad.cson
@@ -85,7 +85,23 @@
     ]
   }
   {
-    'match': '\\b(abs|acos|asun|atan|atan2|ceil|cos|exp|floor|ln|log|lookup|max|min|pow|rands|round|sign|sin|sqrt|tan|str|cube|sphere|cylinder|polyhedron|scale|rotate|translate|mirror|multimatrix|color|minkowski|hull|union|difference|intersection|echo)\\b'
+    'match': '\\b(abs|acos|asin|atan|atan2|ceil|cos|exp|floor|len|let|ln|log|max|min|pow|rands|round|sign|sin|sqrt|tan)\\b'
+    'name': 'support.function.mathematical.scad'
+  }
+  {
+    'match': '\\b(circle|square|polygon|text|cube|sphere|cylinder|polyhedron)\\b'
+    'name': 'support.function.shape.scad'
+  }
+  {
+    'match': '\\b(scale|rotate|translate|resize|mirror|multimatrix|color|minkowski|hull)\\b'
+    'name': 'support.function.transformation.scad'
+  }
+  {
+    'match': '\\b(union|difference|intersection)\\b'
+    'name': 'support.function.boolean.scad'
+  }
+  {
+    'match': '\\b(echo|concat|lookup|str|chr|search|version|version_num|norm|cross|parent_module|import|linear_extrude|rotate_extrude|surface|projection|children)\\b'
     'name': 'support.function.scad'
   }
   {

--- a/snippets/language-openscad.cson
+++ b/snippets/language-openscad.cson
@@ -7,19 +7,22 @@
     'body': 'module ${1:module_name}(${2:args}) {\n\t${0:// body...}\n}'
   'assign':
     'prefix': 'ass'
-    'body': 'assign (${1:x} = ${2:0}) {\n\t${}$0\n}\n'
+    'body': 'assign (${1:x} = ${2:0}) ${4:{\n\t${0:object();}\n\\}}'
   'circle':
     'prefix': 'cir'
     'body': 'circle(r=${1:10});'
   'color':
     'prefix': 'col'
-    'body': 'color([${1:0}/255, ${2:0}/255, ${3:0}/255]) {\n\t${0}\n}'
+    'body': 'color([${1:0}/255, ${2:0}/255, ${3:0}/255]) ${4:{\n\t${0:object();}\n\\}}'
   'cube':
     'prefix': 'cu'
     'body': 'cube(size=[${1:10}, ${2:10}, ${3:10}], center=${4:true});'
   'cylinder':
     'prefix': 'cyl'
     'body': 'cylinder(r=${1:10}, h=${2:10}, center=${3:true});'
+  'difference':
+    'prefix': 'diff'
+    'body': 'difference() {\n\t${1:object();}\n}'
   'echo':
     'prefix': 'echo'
     'body': 'echo(str("${1:Variable = }", ${2:x}));'
@@ -41,6 +44,9 @@
   'include':
     'prefix': 'inc'
     'body': 'include <${1:filename.scad}>'
+  'intersection':
+    'prefix': 'int'
+    'body': 'intersection() {\n\t${1:object();}\n}'
   'intersection_for (...) {...}':
     'prefix': 'ifor'
     'body': 'for (${20:i} = [${1:0}:${2:10}]) {\n\t${}$0\n}\n'
@@ -73,16 +79,16 @@
     'body': 'rotate([${1:0}, ${2:0}, ${3:0}]) ${0}'
   'rotate(...) {...}':
     'prefix': 'rot'
-    'body': 'rotate([${1:10}, ${2:10}, ${3:10}]) {\n\t${0}\n}\n'
+    'body': 'rotate([${1:10}, ${2:10}, ${3:10}]) ${4:{\n\t${0:object();}\n\\}}'
   'rotate_extrude':
     'prefix': 're'
-    'body': 'rotate_extrude(convexity=${1:10}) {\n\t${0}\n}'
+    'body': 'rotate_extrude(convexity=${1:10}) ${4:{\n\t${0:object();}\n\\}}'
   'scale(...)':
     'prefix': 's'
     'body': 'scale([${1:1}, ${2:1}, ${3:1}]) ${0}'
   'scale(...) {...}':
     'prefix': 'sca'
-    'body': 'scale([${1:1}, ${2:1}, ${3:1}]) {\n\t${0}\n}'
+    'body': 'scale([${1:1}, ${2:1}, ${3:1}]) ${4:{\n\t${0:object();}\n\\}}'
   'sphere':
     'prefix': 'sph'
     'body': 'sphere(r=${1:10});'
@@ -97,7 +103,10 @@
     'body': 'translate([${1:0}, ${2:0}, ${3:0}]) ${0}'
   'translate(...) {...}':
     'prefix': 'tran'
-    'body': 'translate([${1:0}, ${2:0}, ${3:0}]) {\n\t${0}\n}'
+    'body': 'translate([${1:0}, ${2:0}, ${3:0}]) ${4:{\n\t${0:object();}\n\\}}'
+  'union':
+    'prefix': 'uni'
+    'body': 'union() {\n\t${1:object();}\n}'
   'use':
     'prefix': 'use'
     'body': 'use <${1:filename.scad}>'


### PR DESCRIPTION
- Included snippets for the boolean operators (union, intersection, difference)
- Enhanced the bracketing for block-optional functions (e.g. translate, rotate, scale) - now on tab it selects the whole bracket first, allowing you to delete it if you wish, then a second tab brings you inside the bracket. This allows you to use the same snippet for both w/ and w/o bracket (still worth keeping the single-letter no-bracket snippets in there for those who currently use them)
